### PR TITLE
Refactor API routes, add planning job WebSocket updates, and improve item matching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
 			"username": "postgres",
 			"password": "postgres"
 		}
-	]
+	],
+	"python.languageServer": "None"
 }

--- a/backend/.env
+++ b/backend/.env
@@ -8,5 +8,5 @@ SAVERY_REDOC_URL=/redoc
 SAVERY_OPENAPI_URL=/openapi.json
 SAVERY_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/savery
 SAVERY_CELERY_BROKER_URL=amqp://guest:guest@localhost//
-SAVERY_CELERY_RESULT_BACKEND=rpc://
+SAVERY_CELERY_RESULT_BACKEND=redis://localhost:6379/0
 SAVERY_CELERY_MATCH_TASK=workers.item_matches.run_job

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,10 +2,11 @@
 
 from fastapi import APIRouter
 
-from .routes import catalog, health, lists, planning
+from .routes import catalog, health, lists, planning, tasks_websocket
 
 api_router = APIRouter()
 api_router.include_router(health.router, prefix="", tags=["health"])
 api_router.include_router(lists.router, prefix="", tags=["lists"])
 api_router.include_router(catalog.router, prefix="", tags=["catalog"])
 api_router.include_router(planning.router, prefix="", tags=["planning"])
+api_router.include_router(tasks_websocket.router, prefix="", tags=["jobs"])

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,5 +1,5 @@
 """API route modules."""
 
-from . import catalog, health, lists, planning
+from . import catalog, health, lists, planning, tasks_websocket
 
-__all__ = ["catalog", "health", "lists", "planning"]
+__all__ = ["catalog", "health", "lists", "planning", "tasks_websocket"]

--- a/backend/app/api/routes/planning/planning_job_endpoints.py
+++ b/backend/app/api/routes/planning/planning_job_endpoints.py
@@ -160,6 +160,34 @@ def list_plan_route_jobs(
 
 
 @router.get(
+    "/route-plans/{route_plan_id}/plan-route-jobs/active",
+    response_model=JobResponse,
+    summary="Get plan route job thats active for the route plan",
+)
+def get_plan_route_job_active(
+    route_plan_id: UUID,
+    db: Session = Depends(get_db),
+) -> JobResponse:
+
+    _get_route_plan_or_404(db, route_plan_id)
+
+    statement = (
+        select(Job)
+        .where(
+            Job.plan_id == route_plan_id,
+            Job.stage == JobStage.OPTIMIZE,
+            Job.status.in_((JobStatus.PENDING, JobStatus.RUNNING)),
+        )
+        .order_by(Job.updated_at.desc())
+    )
+
+    result = db.exec(statement).first()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active plan route job found")
+    return JobResponse.model_validate(result)
+
+
+@router.get(
     "/route-plans/{route_plan_id}/plan-route-jobs/{job_id}",
     response_model=JobResponse,
     summary="Get plan route job by ID",
@@ -185,34 +213,6 @@ def get_plan_route_job_by_id(
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route plan job not found")
 
-    return JobResponse.model_validate(result)
-
-
-@router.get(
-    "/route-plans/{route_plan_id}/plan-route-jobs/active",
-    response_model=JobResponse,
-    summary="Get plan route job thats active for the route plan",
-)
-def get_plan_route_job_active(
-    route_plan_id: UUID,
-    db: Session = Depends(get_db),
-) -> JobResponse:
-
-    _get_route_plan_or_404(db, route_plan_id)
-
-    statement = (
-        select(Job)
-        .where(
-            Job.plan_id == route_plan_id,
-            Job.stage == JobStage.OPTIMIZE,
-            Job.status.in_((JobStatus.PENDING, JobStatus.RUNNING)),
-        )
-        .order_by(Job.updated_at.desc())
-    )
-
-    result = db.exec(statement).first()
-    if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active plan route job found")
     return JobResponse.model_validate(result)
 
 
@@ -357,35 +357,6 @@ def list_item_match_jobs(
 
 
 @router.get(
-    "/route-plans/{route_plan_id}/item-match-jobs/{job_id}",
-    response_model=JobResponse,
-    summary="Get item match job by ID",
-)
-def get_item_match_job_by_id(
-    route_plan_id: UUID,
-    job_id: UUID,
-    db: Session = Depends(get_db),
-) -> JobResponse:
-
-    _get_route_plan_or_404(db, route_plan_id)
-
-    statement = (
-        select(Job)
-        .where(
-            Job.plan_id == route_plan_id,
-            Job.id == job_id,
-            Job.stage == JobStage.MATCH,
-        )
-        .order_by(Job.updated_at.desc())
-    )
-    result = db.exec(statement).first()
-    if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item match job not found")
-
-    return JobResponse.model_validate(result)
-
-
-@router.get(
     "/route-plans/{route_plan_id}/item-match-jobs/active",
     response_model=JobResponse,
     summary="Get item match job thats active for the route plan",
@@ -410,6 +381,35 @@ def get_item_match_job_active(
     result = db.exec(statement).first()
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active item match job found")
+
+    return JobResponse.model_validate(result)
+
+
+@router.get(
+    "/route-plans/{route_plan_id}/item-match-jobs/{job_id}",
+    response_model=JobResponse,
+    summary="Get item match job by ID",
+)
+def get_item_match_job_by_id(
+    route_plan_id: UUID,
+    job_id: UUID,
+    db: Session = Depends(get_db),
+) -> JobResponse:
+
+    _get_route_plan_or_404(db, route_plan_id)
+
+    statement = (
+        select(Job)
+        .where(
+            Job.plan_id == route_plan_id,
+            Job.id == job_id,
+            Job.stage == JobStage.MATCH,
+        )
+        .order_by(Job.updated_at.desc())
+    )
+    result = db.exec(statement).first()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item match job not found")
 
     return JobResponse.model_validate(result)
 
@@ -555,35 +555,6 @@ def list_item_fanout_jobs(
 
 
 @router.get(
-    "/route-plans/{route_plan_id}/item-fanout-jobs/{job_id}",
-    response_model=JobResponse,
-    summary="Get item match fanout job by ID",
-)
-def get_item_fanout_job_by_id(
-    route_plan_id: UUID,
-    job_id: UUID,
-    db: Session = Depends(get_db),
-) -> JobResponse:
-
-    _get_route_plan_or_404(db, route_plan_id)
-
-    statement = (
-        select(Job)
-        .where(
-            Job.plan_id == route_plan_id,
-            Job.id == job_id,
-            Job.stage == JobStage.FANOUT,
-        )
-        .order_by(Job.updated_at.desc())
-    )
-    result = db.exec(statement).first()
-    if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item fanout job not found")
-
-    return JobResponse.model_validate(result)
-
-
-@router.get(
     "/route-plans/{route_plan_id}/item-fanout-jobs/active",
     response_model=JobResponse,
     summary="Get item match fanout job thats active for the route plan",
@@ -608,6 +579,35 @@ def get_item_fanout_job_active(
     result = db.exec(statement).first()
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active item fanout job found")
+
+    return JobResponse.model_validate(result)
+
+
+@router.get(
+    "/route-plans/{route_plan_id}/item-fanout-jobs/{job_id}",
+    response_model=JobResponse,
+    summary="Get item match fanout job by ID",
+)
+def get_item_fanout_job_by_id(
+    route_plan_id: UUID,
+    job_id: UUID,
+    db: Session = Depends(get_db),
+) -> JobResponse:
+
+    _get_route_plan_or_404(db, route_plan_id)
+
+    statement = (
+        select(Job)
+        .where(
+            Job.plan_id == route_plan_id,
+            Job.id == job_id,
+            Job.stage == JobStage.FANOUT,
+        )
+        .order_by(Job.updated_at.desc())
+    )
+    result = db.exec(statement).first()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item fanout job not found")
 
     return JobResponse.model_validate(result)
 

--- a/backend/app/api/routes/planning/planning_job_endpoints.py
+++ b/backend/app/api/routes/planning/planning_job_endpoints.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from backend.app.dependencies import get_db
@@ -67,7 +68,16 @@ def create_plan_route_job(
             job.task_id = ""
 
     db.add(job)
-    db.commit()
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A route planning job is already running for this route plan",
+        )
+
     db.refresh(job)
 
     try:
@@ -121,11 +131,8 @@ def cancel_plan_route_job(
     if job.task_id:
         celery_app.control.revoke(job.task_id, terminate=True)
 
-    job.status = JobStatus.FAILED
-    if job.message:
-        job.message = f"{job.message}; Cancelled by user"
-    else:
-        job.message = "Cancelled by user"
+    job.status = JobStatus.CANCELLED
+    job.message = "Cancelled by user"
     job.completed_at = utcnow()
     db.add(job)
     db.commit()
@@ -264,7 +271,16 @@ def create_item_match_job(
             job.task_id = ""
 
     db.add(job)
-    db.commit()
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An item match job is already running for this route plan",
+        )
+
     db.refresh(job)
 
     try:
@@ -318,11 +334,8 @@ def cancel_item_match_job(
     if job.task_id:
         celery_app.control.revoke(job.task_id, terminate=True)
 
-    job.status = JobStatus.FAILED
-    if job.message:
-        job.message = f"{job.message}; Cancelled by user"
-    else:
-        job.message = "Cancelled by user"
+    job.status = JobStatus.CANCELLED
+    job.message = "Cancelled by user"
     job.completed_at = utcnow()
     db.add(job)
     db.commit()
@@ -462,7 +475,16 @@ def create_item_fanout_job(
             job.task_id = ""
 
     db.add(job)
-    db.commit()
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An item fanout job is already running for this route plan",
+        )
+
     db.refresh(job)
 
     try:
@@ -516,11 +538,8 @@ def cancel_item_fanout_job(
     if job.task_id:
         celery_app.control.revoke(job.task_id, terminate=True)
 
-    job.status = JobStatus.FAILED
-    if job.message:
-        job.message = f"{job.message}; Cancelled by user"
-    else:
-        job.message = "Cancelled by user"
+    job.status = JobStatus.CANCELLED
+    job.message = "Cancelled by user"
     job.completed_at = utcnow()
     db.add(job)
     db.commit()

--- a/backend/app/api/routes/tasks_websocket.py
+++ b/backend/app/api/routes/tasks_websocket.py
@@ -1,0 +1,132 @@
+"""WebSocket endpoint that streams Job status updates to clients."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Query, WebSocket
+from fastapi.encoders import jsonable_encoder
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from ...models import JobStatus
+from ...task_status import job_status_manager
+from ...tasks import get_job_status
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+TERMINAL_STATUSES = {JobStatus.SUCCESS.value, JobStatus.FAILED.value}
+DB_POLL_INTERVAL_SECONDS = 1.0
+MAX_DB_POLL_INTERVAL_SECONDS = 5.0
+QUEUE_MAXSIZE = 100
+
+
+async def _load_job_status(job_id: UUID) -> dict[str, Any]:
+    """Fetch the latest persisted job payload in a worker thread."""
+
+    return await asyncio.to_thread(get_job_status, job_id)
+
+
+def _extract_payload_from_meta(meta: Any) -> dict[str, Any] | None:
+    """Return the job payload embedded in a Celery result backend message, if present."""
+
+    if not isinstance(meta, dict):
+        return None
+
+    candidate = meta.get("result")
+    if isinstance(candidate, dict) and candidate.get("id"):
+        return candidate
+
+    # Some backends may pass the full payload directly in the message.
+    if meta.get("id") and meta.get("status"):
+        return meta  # type: ignore[return-value]
+
+    return None
+
+
+@router.websocket("/ws/jobs/{job_id}")
+async def stream_job_status(websocket: WebSocket, job_id: UUID, plan_id: UUID | None = Query(default=None)) -> None:
+    """Push real-time job progress to clients with a Celery backend feed and DB fallback."""
+
+    try:
+        initial_payload = await _load_job_status(job_id)
+    except ValueError:
+        await websocket.close(code=4404)
+        return
+
+    if plan_id is not None and initial_payload.get("plan_id") != str(plan_id):
+        logger.debug("Rejecting websocket for job %s due to plan mismatch (%s != %s)", job_id, plan_id, initial_payload.get("plan_id"))
+        await websocket.close(code=4404)
+        return
+
+    await websocket.accept()
+    await websocket.send_json(jsonable_encoder(initial_payload))
+
+    task_id = initial_payload.get("task_id")
+    loop = asyncio.get_running_loop()
+    subscription_queue: asyncio.Queue[dict[str, Any]] | None = None
+    poll_interval = DB_POLL_INTERVAL_SECONDS
+
+    if task_id:
+        subscription_queue = asyncio.Queue(maxsize=QUEUE_MAXSIZE)
+        if not await job_status_manager.subscribe(task_id, subscription_queue):
+            subscription_queue = None
+            logger.info("Falling back to DB polling for job %s (task %s)", job_id, task_id)
+
+    last_payload = initial_payload
+
+    try:
+        while True:
+            broker_payload: dict[str, Any] | None = None
+
+            if subscription_queue is not None:
+                try:
+                    meta = await asyncio.wait_for(subscription_queue.get(), timeout=poll_interval)
+                    broker_payload = _extract_payload_from_meta(meta)
+                except asyncio.TimeoutError:
+                    pass
+            else:
+                await asyncio.sleep(poll_interval)
+
+            if broker_payload is not None:
+                current_payload = broker_payload
+            else:
+                try:
+                    current_payload = await _load_job_status(job_id)
+                except ValueError:
+                    await websocket.close(code=4404)
+                    break
+
+            if plan_id is not None and current_payload.get("plan_id") != str(plan_id):
+                await websocket.close(code=4404)
+                break
+
+            if current_payload != last_payload:
+                await websocket.send_json(jsonable_encoder(current_payload))
+                last_payload = current_payload
+                poll_interval = DB_POLL_INTERVAL_SECONDS
+            else:
+                poll_interval = min(MAX_DB_POLL_INTERVAL_SECONDS, poll_interval * 2)
+
+            if current_payload.get("status") in TERMINAL_STATUSES:
+                break
+    except WebSocketDisconnect:
+        logger.debug("Client disconnected from job %s websocket", job_id)
+    except Exception as exc:  # pragma: no cover - defensive logging for unexpected failures
+        logger.exception("Unhandled error in job status websocket for %s: %s", job_id, exc)
+        try:
+            await websocket.send_json({"error": "Internal server error", "message": str(exc)})
+            await websocket.close(code=1011)
+        except Exception:
+            pass
+    finally:
+        if subscription_queue is not None and task_id:
+            await job_status_manager.unsubscribe(task_id, subscription_queue)
+        if websocket.client_state != WebSocketState.DISCONNECTED:
+            try:
+                await websocket.close()
+            except Exception:
+                pass

--- a/backend/app/api/routes/tasks_websocket.py
+++ b/backend/app/api/routes/tasks_websocket.py
@@ -18,7 +18,7 @@ from ...tasks import get_job_status
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-TERMINAL_STATUSES = {JobStatus.SUCCESS.value, JobStatus.FAILED.value}
+TERMINAL_STATUSES = {JobStatus.SUCCESS.value, JobStatus.FAILED.value, JobStatus.CANCELLED.value}
 DB_POLL_INTERVAL_SECONDS = 1.0
 MAX_DB_POLL_INTERVAL_SECONDS = 5.0
 QUEUE_MAXSIZE = 100
@@ -118,7 +118,7 @@ async def stream_job_status(websocket: WebSocket, job_id: UUID, plan_id: UUID | 
     except Exception as exc:  # pragma: no cover - defensive logging for unexpected failures
         logger.exception("Unhandled error in job status websocket for %s: %s", job_id, exc)
         try:
-            await websocket.send_json({"error": "Internal server error", "message": str(exc)})
+            await websocket.send_json({"error": "Internal server error", "message": "An unexpected error occurred"})
             await websocket.close(code=1011)
         except Exception:
             pass

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/savery"
 
     celery_broker_url: str = "amqp://guest:guest@localhost//"
-    celery_result_backend: str = "rpc://"
+    celery_result_backend: str = "redis://localhost:6379/0"
     celery_health_task: str = "workers.health.run_demo"
     celery_demo_task_delay_seconds: float = 0.01
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
 
     celery_match_task: str = "workers.item_matches.create_item_match_candidates"
     celery_fanout_task: str = "workers.item_matches.fanout_candidates_to_item_matches"
+    celery_optimize_task: str = "workers.optimize.optimize_route_plan"
 
     task_status_base_url: Optional[str] = None
 

--- a/backend/app/lifecycle.py
+++ b/backend/app/lifecycle.py
@@ -4,10 +4,12 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from redis.asyncio import Redis
 
 from backend.app.config import settings
 from backend.app.db import create_db_and_tables
 from backend.app.migrations import upgrade_to_head
+from backend.app.task_status import job_status_manager
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +27,18 @@ async def lifespan(app: FastAPI):
             logger.error("Database migration failed: %s", exc)
             raise
 
-    # Insert startup initialization (DB, caches, etc.) here.
-    yield
-    # Insert graceful shutdown logic here.
+    if settings.celery_result_backend.startswith(("redis://", "rediss://")):
+        try:
+            async with Redis.from_url(settings.celery_result_backend) as redis_client:
+                await redis_client.ping()
+        except Exception as exc:
+            logger.error("Failed to connect to Redis result backend: %s", exc)
+            raise
+
+    await job_status_manager.start()
+
+    try:
+        yield
+    finally:
+        await job_status_manager.stop()
     logger.info("Stopping %s", app.title)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -47,6 +47,7 @@ class JobStatus(str, Enum):
     RUNNING = "RUNNING"
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
 
 
 # Base class -------------------------------------------------------------------
@@ -489,3 +490,6 @@ Index(
     unique=True,
     postgresql_where=Job.status.in_((JobStatus.PENDING, JobStatus.RUNNING)),
 )
+
+# Terminal statuses that indicate a job is no longer active
+TERMINAL_JOB_STATUSES = frozenset({JobStatus.SUCCESS, JobStatus.FAILED, JobStatus.CANCELLED})

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -449,13 +449,6 @@ class PlanItem(Base, table=True):
 
 class Job(Base, table=True):
     __tablename__ = "jobs"
-    __table_args__ = (
-        UniqueConstraint(
-            "plan_id",
-            "stage",
-            name="uq_jobs_plan_stage",
-        ),
-    )
 
     plan_id: UUID = Field(foreign_key="route_plans.id", nullable=False, index=True)
     plan: RoutePlan | None = Relationship(back_populates="jobs")
@@ -488,4 +481,11 @@ Index(
     "ix_price_entries_store_product_fetched_at",
     PriceEntry.store_product_id,
     PriceEntry.fetched_at,
+)
+Index(
+    "ix_jobs_plan_stage_active",
+    Job.plan_id,
+    Job.stage,
+    unique=True,
+    postgresql_where=Job.status.in_((JobStatus.PENDING, JobStatus.RUNNING)),
 )

--- a/backend/app/task_status.py
+++ b/backend/app/task_status.py
@@ -1,0 +1,270 @@
+"""Bridge Celery task result events to WebSocket subscribers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from typing import Any, DefaultDict, Set
+
+from celery.backends.base import DisabledBackend
+from celery.states import READY_STATES
+
+from backend.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+class JobStatusManager:
+    """Stream Celery task state changes to interested listeners."""
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._result_consumer = None
+        self._drain_task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event | None = None
+        self._queues: DefaultDict[str, Set[asyncio.Queue[Any]]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+        self._enabled: bool = False
+        self._start_attempted: bool = False
+        self._queue_drop_counts: DefaultDict[asyncio.Queue[Any], int] = defaultdict(int)
+        self._canceling: Set[str] = set()
+
+    @property
+    def _queue_full_drop_threshold(self) -> int:
+        """Number of consecutive QueueFull events before dropping a listener."""
+
+        return 3
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when the Celery consumer is active."""
+
+        return self._enabled
+
+    async def start(self) -> None:
+        """Initialise the Celery ResultConsumer and background drain loop."""
+
+        if self._enabled:
+            return
+
+        try:
+            backend = celery_app.backend
+        except Exception as exc:
+            if not self._start_attempted:
+                logger.warning(
+                    "Unable to initialise Celery result backend; job websocket streaming will fall back to DB polling: %s",
+                    exc,
+                )
+            self._start_attempted = True
+            return
+
+        if backend is None or isinstance(backend, DisabledBackend):
+            if not self._start_attempted:
+                logger.warning(
+                    "Celery result backend unavailable; job websocket streaming will fall back to DB polling"
+                )
+            self._start_attempted = True
+            return
+
+        consumer = getattr(backend, "result_consumer", None)
+        if consumer is None:
+            if not self._start_attempted:
+                logger.warning(
+                    "Celery backend does not expose a result consumer; job websocket streaming will fall back to DB polling"
+                )
+            self._start_attempted = True
+            return
+
+        self._loop = asyncio.get_running_loop()
+        self._stop_event = asyncio.Event()
+        self._result_consumer = consumer
+        self._result_consumer.on_message = self._handle_message
+        self._enabled = True
+        self._start_attempted = True
+        self._drain_task = asyncio.create_task(self._drain_loop())
+        logger.info("Started Celery result consumer for job status websockets")
+
+    async def stop(self) -> None:
+        """Tear down the consumer and background task."""
+
+        if self._stop_event:
+            self._stop_event.set()
+
+        if self._drain_task:
+            await self._drain_task
+
+        if self._result_consumer:
+            try:
+                await asyncio.to_thread(self._result_consumer.stop)
+            except Exception as exc:  
+                logger.warning("Failed to stop result consumer cleanly: %s", exc)
+
+        self._drain_task = None
+        self._result_consumer = None
+        self._stop_event = None
+        self._enabled = False
+        self._start_attempted = False
+        self._queues.clear()
+        self._queue_drop_counts.clear()
+        self._canceling.clear()
+        logger.info("Stopped Celery result consumer for job status websockets")
+
+    async def subscribe(self, task_id: str, queue: asyncio.Queue[Any]) -> bool:
+        """Subscribe an async queue to receive state changes for the task."""
+
+        await self.start()
+        if not self._enabled or self._result_consumer is None:
+            return False
+
+        async with self._lock:
+            self._queues[task_id].add(queue)
+            self._queue_drop_counts.pop(queue, None)
+
+        try:
+            await asyncio.to_thread(self._result_consumer.consume_from, task_id)
+        except Exception as exc:
+            logger.warning("Failed to subscribe to task %s updates via Celery backend: %s", task_id, exc)
+            async with self._lock:
+                listeners = self._queues.get(task_id)
+                if listeners and queue in listeners:
+                    listeners.remove(queue)
+                    if not listeners:
+                        self._queues.pop(task_id, None)
+            return False
+
+        return True
+
+    async def unsubscribe(self, task_id: str, queue: asyncio.Queue[Any]) -> None:
+        """Remove a queue subscription and cancel the backend feed if idle."""
+
+        cancel_backend = False
+
+        async with self._lock:
+            self._canceling.add(task_id)
+            listeners = self._queues.get(task_id)
+            if listeners and queue in listeners:
+                listeners.remove(queue)
+                self._queue_drop_counts.pop(queue, None)
+                if not listeners:
+                    self._queues.pop(task_id, None)
+                    cancel_backend = True
+
+        if cancel_backend and self._enabled and self._result_consumer is not None:
+            try:
+                await asyncio.to_thread(self._result_consumer.cancel_for, task_id)
+            except Exception as exc:  
+                logger.debug("Failed to cancel result consumer for %s: %s", task_id, exc)
+            finally:
+                async with self._lock:
+                    self._canceling.discard(task_id)
+        else:
+            async with self._lock:
+                self._canceling.discard(task_id)
+
+    async def _auto_unsubscribe(self, task_id: str) -> None:
+        """Detach result consumer subscriptions once a task reaches a terminal state."""
+
+        cancel_backend = False
+
+        async with self._lock:
+            self._canceling.add(task_id)
+            listeners = self._queues.pop(task_id, None)
+            if listeners:
+                cancel_backend = True
+                for listener in listeners:
+                    self._queue_drop_counts.pop(listener, None)
+
+        try:
+            if cancel_backend and self._enabled and self._result_consumer is not None:
+                try:
+                    await asyncio.to_thread(self._result_consumer.cancel_for, task_id)
+                except Exception as exc:  
+                    logger.debug("Failed to cancel result consumer for %s: %s", task_id, exc)
+        finally:
+            async with self._lock:
+                self._canceling.discard(task_id)
+
+    async def _drain_loop(self) -> None:
+        """Continuously drain the Celery result backend for state changes."""
+
+        if self._result_consumer is None or self._stop_event is None:
+            return
+
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.to_thread(self._result_consumer.drain_events, timeout=1.0)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc: 
+                logger.warning("Error while draining task status events: %s", exc)
+                await asyncio.sleep(1.0)
+
+    def _handle_message(self, meta: dict[str, Any]) -> None:
+        """Thread-safe hook invoked by the Celery result consumer."""
+
+        if not self._loop:
+            return
+        if self._loop.is_closed():
+            return
+        self._loop.call_soon_threadsafe(lambda: self._loop.create_task(self._dispatch_message(meta)))
+
+    async def _dispatch_message(self, meta: dict[str, Any]) -> None:
+        """Fan out a Celery state change to all subscribed queues."""
+
+        task_id = meta.get("task_id")
+        if not task_id:
+            return
+
+        async with self._lock:
+            if task_id in self._canceling:
+                return
+            listeners = list(self._queues.get(task_id, ()))
+
+        if not listeners:
+            return
+
+        failed_queues: list[asyncio.Queue[Any]] = []
+        delivered_queues: list[asyncio.Queue[Any]] = []
+
+        for queue in listeners:
+            try:
+                queue.put_nowait(meta)
+                delivered_queues.append(queue)
+            except asyncio.QueueFull:
+                failed_queues.append(queue)
+                logger.debug("Dropping task status event for %s because the queue is full", task_id)
+
+        cancel_backend = False
+        if failed_queues or delivered_queues:
+            async with self._lock:
+                if task_id in self._canceling:
+                    return
+                for queue in delivered_queues:
+                    self._queue_drop_counts.pop(queue, None)
+                for queue in failed_queues:
+                    failures = self._queue_drop_counts[queue] + 1
+                    if failures >= self._queue_full_drop_threshold:
+                        listeners_for_task = self._queues.get(task_id)
+                        if listeners_for_task and queue in listeners_for_task:
+                            listeners_for_task.remove(queue)
+                            self._queue_drop_counts.pop(queue, None)
+                            if not listeners_for_task:
+                                self._queues.pop(task_id, None)
+                                cancel_backend = True
+                    else:
+                        self._queue_drop_counts[queue] = failures
+
+        if cancel_backend and self._enabled and self._result_consumer is not None:
+            try:
+                await asyncio.to_thread(self._result_consumer.cancel_for, task_id)
+            except Exception as exc:  
+                logger.debug("Failed to cancel result consumer for %s: %s", task_id, exc)
+
+        if meta.get("status") in READY_STATES:
+            asyncio.create_task(self._auto_unsubscribe(task_id))
+
+
+job_status_manager = JobStatusManager()
+
+__all__ = ["job_status_manager", "JobStatusManager"]

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Protocol
 from uuid import UUID
 
@@ -11,6 +12,8 @@ from backend.app.config import settings
 from backend.app.db import session_scope
 from backend.app.models import Job, JobStage, JobStatus, utcnow
 from backend.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
 
 
 class TaskStateReporter(Protocol):
@@ -33,6 +36,18 @@ def _as_uuid(value: str | UUID) -> UUID:
     """Normalize string or UUID inputs so we can work with a consistent type."""
 
     return value if isinstance(value, UUID) else UUID(str(value))
+
+
+def _publish_task_state(task: TaskStateReporter, state: str, meta: dict[str, Any]) -> None:
+    """Send updates to Celery only when a task_id is available."""
+
+    task_id = getattr(getattr(task, "request", None), "id", None)
+    if not task_id:
+        return
+    try:
+        task.update_state(state=state, meta=meta)
+    except Exception as exc:  # pragma: no cover - defensive logging for broker/backend hiccups
+        logger.debug("Failed to publish state %s for task %s: %s", state, task_id, exc)
 
 
 def _get_job(session: Session, job_id: UUID) -> Job:
@@ -96,7 +111,7 @@ def mark_job_running(
     total: int | None = None,
     message: str | None = None,
     task: TaskStateReporter,
-    include_status: bool = False,
+    include_status: bool = True,
     extra_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Set the job state to RUNNING and optionally notify Celery of the update."""
@@ -114,7 +129,7 @@ def mark_job_running(
         session.add(job)
 
         meta_payload = _build_task_meta(job, include_status, extra_meta)
-        task.update_state(state="STARTED", meta=meta_payload)
+        _publish_task_state(task, "STARTED", meta_payload)
 
     return meta_payload
 
@@ -126,7 +141,7 @@ def record_job_progress(
     total: int | None = None,
     message: str | None = None,
     task: TaskStateReporter,
-    include_status: bool = False,
+    include_status: bool = True,
     extra_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Update the current progress counters for the job."""
@@ -144,7 +159,7 @@ def record_job_progress(
         session.add(job)
 
         meta_payload = _build_task_meta(job, include_status, extra_meta)
-        task.update_state(state="PROGRESS", meta=meta_payload)
+        _publish_task_state(task, "PROGRESS", meta_payload)
 
     return meta_payload
 
@@ -154,7 +169,7 @@ def mark_job_success(
     *,
     message: str | None = None,
     task: TaskStateReporter,
-    include_status: bool = False,
+    include_status: bool = True,
     extra_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Mark the job as successful and optionally attach a completion message."""
@@ -178,7 +193,7 @@ def mark_job_success(
         session.add(job)
 
         meta_payload = _build_task_meta(job, include_status, extra_meta)
-        task.update_state(state="SUCCESS", meta=meta_payload)
+        _publish_task_state(task, "SUCCESS", meta_payload)
 
     return meta_payload
 
@@ -188,7 +203,7 @@ def mark_job_failed(
     *,
     message: str | None = None,
     task: TaskStateReporter,
-    include_status: bool = False,
+    include_status: bool = True,
     extra_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Mark the job as failed and capture the error details."""
@@ -204,7 +219,7 @@ def mark_job_failed(
         session.add(job)
 
         meta_payload = _build_task_meta(job, include_status, extra_meta)
-        task.update_state(state="FAILURE", meta=meta_payload)
+        _publish_task_state(task, "FAILURE", meta_payload)
 
     return meta_payload
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -66,7 +66,7 @@ def _task_name_for_stage(stage: JobStage) -> str:
         JobStage.MATCH: settings.celery_match_task,
         JobStage.HEALTHCHECK: settings.celery_health_task,
         JobStage.FANOUT: settings.celery_fanout_task,
-        
+        JobStage.OPTIMIZE: settings.celery_optimize_task,
     }
     task_name = stage_map.get(stage)
     if not task_name:
@@ -179,9 +179,9 @@ def mark_job_success(
     with session_scope() as session:
         job = _get_job(session, job_uuid)
 
-        # Don't overwrite FAILED status (e.g., from cancellation)
+        # Don't overwrite terminal statuses (e.g., from cancellation or failure)
         # This prevents race conditions where the worker completes after cancellation
-        if job.status == JobStatus.FAILED:
+        if job.status in (JobStatus.FAILED, JobStatus.CANCELLED):
             return _build_task_meta(job, include_status, extra_meta)
 
         job.status = JobStatus.SUCCESS

--- a/backend/migrations/versions/521f6725e059_add_cancelled_job_status.py
+++ b/backend/migrations/versions/521f6725e059_add_cancelled_job_status.py
@@ -1,0 +1,31 @@
+"""Add CANCELLED value to jobstatus enum.
+
+Revision ID: 521f6725e059
+Revises: c3e0a5f6a9f1
+Create Date: 2025-11-25
+
+"""
+from alembic import op
+
+
+revision = "521f6725e059"
+down_revision = "c3e0a5f6a9f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add CANCELLED value to the jobstatus enum for user-cancelled jobs."""
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE jobstatus ADD VALUE IF NOT EXISTS 'CANCELLED'")
+
+
+def downgrade() -> None:
+    """No downgrade available for enum value additions."""
+
+    # Removing values from a PostgreSQL enum requires recreating the type,
+    # which is intentionally omitted here.
+    pass
+

--- a/backend/migrations/versions/c3e0a5f6a9f1_allow_multiple_job_runs_per_stage.py
+++ b/backend/migrations/versions/c3e0a5f6a9f1_allow_multiple_job_runs_per_stage.py
@@ -1,0 +1,32 @@
+"""Allow multiple job records per stage while keeping only one active."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c3e0a5f6a9f1"
+down_revision = "7a174e9b2a16"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop strict uniqueness across all job records for a plan/stage.
+    op.drop_constraint("uq_jobs_plan_stage", "jobs", type_="unique")
+    # Enforce uniqueness only for active jobs (PENDING/RUNNING).
+    op.create_index(
+        "ix_jobs_plan_stage_active",
+        "jobs",
+        ["plan_id", "stage"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('PENDING', 'RUNNING')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_plan_stage_active", table_name="jobs")
+    op.create_unique_constraint(
+        "uq_jobs_plan_stage",
+        "jobs",
+        ["plan_id", "stage"],
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ alembic
 pgvector
 geoalchemy2
 inflect
+redis>=5

--- a/backend/tests/api/test_item_match_jobs.py
+++ b/backend/tests/api/test_item_match_jobs.py
@@ -116,8 +116,8 @@ def test_create_item_match_job_rejects_when_active_exists(client: TestClient, ro
     assert response.status_code == 409
 
 
-def test_cancel_item_match_job_sets_failed_status(client: TestClient, route_plan: dict[str, UUID]) -> None:
-    """Cancelling a job should mark it as failed and include the message."""
+def test_cancel_item_match_job_sets_cancelled_status(client: TestClient, route_plan: dict[str, UUID]) -> None:
+    """Cancelling a job should mark it as CANCELLED and include the message."""
 
     plan_id = route_plan["route_plan_id"]
     job_id = _create_match_job(plan_id, status=JobStatus.PENDING)
@@ -126,7 +126,7 @@ def test_cancel_item_match_job_sets_failed_status(client: TestClient, route_plan
     assert response.status_code == 200
 
     payload = response.json()
-    assert payload["status"] == JobStatus.FAILED.value
+    assert payload["status"] == JobStatus.CANCELLED.value
     assert payload["message"] == "Cancelled by user"
 
 

--- a/backend/tests/api/test_planning_job_endpoints.py
+++ b/backend/tests/api/test_planning_job_endpoints.py
@@ -1,0 +1,168 @@
+"""Additional coverage for planning job endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+from backend.app.db import session_scope
+from backend.app.main import create_app
+from backend.app.models import Job, JobStage, JobStatus, RoutePlan, ShoppingList, utcnow
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    """Provide a FastAPI test client for exercising the API."""
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _create_route_plan() -> dict[str, UUID]:
+    """Insert the minimal shopping list + route plan graph used by the tests."""
+
+    with session_scope() as session:
+        shopping_list = ShoppingList(client_id=f"test-client-{uuid4()}", title="Planning Jobs Test")
+        session.add(shopping_list)
+        session.flush()
+
+        plan = RoutePlan(list_id=shopping_list.id, client_id=f"token-{uuid4()}")
+        session.add(plan)
+        session.flush()
+
+        return {"shopping_list_id": shopping_list.id, "route_plan_id": plan.id}
+
+
+def _cleanup_route_plan(plan_id: UUID, shopping_list_id: UUID) -> None:
+    """Remove the plan, its jobs, and the backing shopping list."""
+
+    with session_scope() as session:
+        jobs = session.exec(select(Job).where(Job.plan_id == plan_id)).all()
+        for job in jobs:
+            session.delete(job)
+
+        plan = session.get(RoutePlan, plan_id)
+        if plan is not None:
+            session.delete(plan)
+
+        shopping_list = session.get(ShoppingList, shopping_list_id)
+        if shopping_list is not None:
+            session.delete(shopping_list)
+
+
+@pytest.fixture()
+def route_plan() -> Iterator[dict[str, UUID]]:
+    """Create and tear down a route plan for the duration of a test."""
+
+    data = _create_route_plan()
+    try:
+        yield data
+    finally:
+        _cleanup_route_plan(data["route_plan_id"], data["shopping_list_id"])
+
+
+def _create_job(
+    plan_id: UUID,
+    *,
+    stage: JobStage,
+    status: JobStatus = JobStatus.PENDING,
+    **kwargs,
+) -> UUID:
+    """Insert a job for convenience."""
+
+    with session_scope() as session:
+        job = Job(plan_id=plan_id, stage=stage, status=status, **kwargs)
+        session.add(job)
+        session.flush()
+        return job.id
+
+
+def test_list_plan_route_jobs_filters_active_only(client: TestClient, route_plan: dict[str, UUID]) -> None:
+    """Only active OPTIMIZE jobs should be returned when requested."""
+
+    plan_id = route_plan["route_plan_id"]
+    active_id = _create_job(plan_id, stage=JobStage.OPTIMIZE, status=JobStatus.PENDING)
+    _create_job(plan_id, stage=JobStage.OPTIMIZE, status=JobStatus.SUCCESS)
+
+    response = client.get(f"/api/route-plans/{plan_id}/plan-route-jobs", params={"active_only": True})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [UUID(job["id"]) for job in payload] == [active_id]
+    assert payload[0]["status"] == JobStatus.PENDING.value
+
+
+def test_get_plan_route_job_active_returns_404_when_missing(client: TestClient, route_plan: dict[str, UUID]) -> None:
+    """Requesting an active OPTIMIZE job should fail cleanly when none exist."""
+
+    plan_id = route_plan["route_plan_id"]
+    _create_job(plan_id, stage=JobStage.OPTIMIZE, status=JobStatus.SUCCESS)
+
+    response = client.get(f"/api/route-plans/{plan_id}/plan-route-jobs/active")
+
+    assert response.status_code == 404
+
+
+def test_create_item_fanout_job_resets_existing_state(
+    client: TestClient, route_plan: dict[str, UUID], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-running a FANOUT job should reset progress fields before enqueueing."""
+
+    plan_id = route_plan["route_plan_id"]
+    original_id = _create_job(
+        plan_id,
+        stage=JobStage.FANOUT,
+        status=JobStatus.SUCCESS,
+        progress_current=3,
+        progress_total=5,
+        message="done",
+        started_at=utcnow(),
+        completed_at=utcnow(),
+        task_id=None,
+    )
+
+    recorded_job_id: UUID | None = None
+
+    def _fake_enqueue(job_id: UUID) -> str:  # pragma: no cover - injected in test
+        nonlocal recorded_job_id
+        recorded_job_id = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
+        return "fake-task-id"
+
+    monkeypatch.setattr(
+        "backend.app.api.routes.planning.planning_job_endpoints.enqueue_job",
+        _fake_enqueue,
+    )
+
+    response = client.post(f"/api/route-plans/{plan_id}/item-fanout-jobs")
+    assert response.status_code == 201
+
+    payload = response.json()
+    assert UUID(payload["id"]) == original_id
+    assert payload["status"] == JobStatus.PENDING.value
+    assert payload["progress_current"] == 0
+    assert payload["progress_total"] is None
+    assert payload["message"] is None
+    assert payload["started_at"] is None
+    assert payload["completed_at"] is None
+    assert recorded_job_id == original_id
+
+    with session_scope() as session:
+        job = session.get(Job, original_id)
+        assert job is not None
+        assert job.status == JobStatus.PENDING
+        assert job.task_id == ""
+
+
+def test_cancel_item_fanout_job_rejects_non_active_status(client: TestClient, route_plan: dict[str, UUID]) -> None:
+    """Only active FANOUT jobs should be cancellable."""
+
+    plan_id = route_plan["route_plan_id"]
+    job_id = _create_job(plan_id, stage=JobStage.FANOUT, status=JobStatus.SUCCESS)
+
+    response = client.delete(f"/api/route-plans/{plan_id}/item-fanout-jobs/{job_id}")
+
+    assert response.status_code == 400

--- a/backend/tests/api/test_task_status_websocket.py
+++ b/backend/tests/api/test_task_status_websocket.py
@@ -1,0 +1,185 @@
+"""Integration tests for the job status WebSocket endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from backend.app.db import session_scope
+from backend.app.main import create_app
+from backend.app.models import Job, JobStage, JobStatus, RoutePlan, ShoppingList
+import backend.app.api.routes.tasks_websocket as tasks_websocket
+import backend.app.task_status as task_status_module
+import backend.app.lifecycle as lifecycle_module
+
+
+class StubJobStatusManager:
+    """Lightweight stand-in for the Celery-backed manager used in tests."""
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.enabled = True
+
+    async def start(self) -> None:  # pragma: no cover - hook used in lifespan
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover - hook used in lifespan
+        return None
+
+    async def subscribe(self, task_id: str, queue: asyncio.Queue) -> bool:
+        self.queue = queue
+        self.loop = asyncio.get_running_loop()
+        return True
+
+    async def unsubscribe(self, task_id: str, queue: asyncio.Queue) -> None:
+        return None
+
+    def push(self, meta: dict) -> None:
+        """Inject a broker message into the websocket stream."""
+
+        if self.queue and self.loop:
+            asyncio.run_coroutine_threadsafe(self.queue.put(meta), self.loop)
+
+
+def _create_job_with_plan() -> tuple[UUID, UUID]:
+    """Insert a plan and job for test execution."""
+
+    with session_scope() as session:
+        shopping_list = ShoppingList(client_id=f"ws-client-{uuid4()}", title="WebSocket Test")
+        session.add(shopping_list)
+        session.flush()
+
+        plan = RoutePlan(list_id=shopping_list.id, client_id=f"ws-client-{uuid4()}")
+        session.add(plan)
+        session.flush()
+
+        job = Job(
+            plan_id=plan.id,
+            stage=JobStage.MATCH,
+            status=JobStatus.PENDING,
+            task_id="ws-test-task",
+            progress_current=0,
+            progress_total=3,
+        )
+        session.add(job)
+        session.flush()
+
+        return job.id, plan.id
+
+
+def _cleanup_job(job_id: UUID, plan_id: UUID) -> None:
+    """Remove the job and related plan and list artifacts."""
+
+    with session_scope() as session:
+        job = session.get(Job, job_id)
+        plan = session.get(RoutePlan, plan_id)
+        list_id = plan.list_id if plan else None
+
+        if job:
+            session.delete(job)
+        if plan:
+            session.delete(plan)
+        if list_id:
+            shopping_list = session.get(ShoppingList, list_id)
+            if shopping_list:
+                session.delete(shopping_list)
+
+
+def _update_job(job_id: UUID, *, status: JobStatus, current: int, total: int) -> None:
+    """Persist a new snapshot of the job."""
+
+    with session_scope() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        job.status = status
+        job.progress_current = current
+        job.progress_total = total
+        session.add(job)
+
+
+@pytest.fixture()
+def job_record() -> Iterator[tuple[UUID, UUID]]:
+    """Provision and tear down a job for WebSocket streaming tests."""
+
+    job_id, plan_id = _create_job_with_plan()
+    try:
+        yield job_id, plan_id
+    finally:
+        _cleanup_job(job_id, plan_id)
+
+
+def test_job_status_websocket_streams_db_changes(job_record: tuple[UUID, UUID], stub_job_status_manager: StubJobStatusManager) -> None:
+    """WebSocket should push status changes even when falling back to DB polling."""
+
+    job_id, plan_id = job_record
+
+    with TestClient(create_app()) as client:
+        with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={plan_id}") as websocket:
+            initial = websocket.receive_json()
+            assert initial["status"] == JobStatus.PENDING.value
+
+            _update_job(job_id, status=JobStatus.RUNNING, current=1, total=3)
+            running = websocket.receive_json()
+            assert running["status"] == JobStatus.RUNNING.value
+            assert running["progress_current"] == 1
+
+            _update_job(job_id, status=JobStatus.SUCCESS, current=3, total=3)
+            final = websocket.receive_json()
+            assert final["status"] == JobStatus.SUCCESS.value
+            assert final["progress_current"] == 3
+
+
+def test_job_status_websocket_rejects_wrong_plan(job_record: tuple[UUID, UUID], stub_job_status_manager: StubJobStatusManager) -> None:
+    """Handshake should close with 4404 when the plan_id does not match the job."""
+
+    job_id, _plan_id = job_record
+    wrong_plan = uuid4()
+
+    with TestClient(create_app()) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={wrong_plan}") as websocket:
+                websocket.receive_text()
+
+    assert excinfo.value.code == 4404
+
+
+@pytest.fixture()
+def stub_job_status_manager(monkeypatch: pytest.MonkeyPatch) -> Iterator[StubJobStatusManager]:
+    """Swap the Celery-backed manager for an in-process stub in tests."""
+
+    stub = StubJobStatusManager()
+    monkeypatch.setattr(tasks_websocket, "job_status_manager", stub)
+    monkeypatch.setattr(task_status_module, "job_status_manager", stub)
+    monkeypatch.setattr(lifecycle_module, "job_status_manager", stub)
+    yield stub
+
+
+def test_job_status_websocket_forwards_celery_meta(job_record: tuple[UUID, UUID], stub_job_status_manager: StubJobStatusManager) -> None:
+    """Celery broker messages should be forwarded without extra DB polls."""
+
+    job_id, plan_id = job_record
+
+    with TestClient(create_app()) as client:
+        with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={plan_id}") as websocket:
+            initial = websocket.receive_json()
+            assert initial["status"] == JobStatus.PENDING.value
+
+            running_payload = {**initial, "status": JobStatus.RUNNING.value, "progress_current": 2}
+            stub_job_status_manager.push({"task_id": initial["task_id"], "status": "PROGRESS", "result": running_payload})
+
+            running = websocket.receive_json()
+            assert running["status"] == JobStatus.RUNNING.value
+            assert running["progress_current"] == 2
+
+            success_payload = {**running_payload, "status": JobStatus.SUCCESS.value, "progress_current": 3, "progress_total": 3}
+            stub_job_status_manager.push({"task_id": initial["task_id"], "status": "SUCCESS", "result": success_payload})
+
+            final = websocket.receive_json()
+            assert final["status"] == JobStatus.SUCCESS.value
+            assert final["progress_current"] == 3

--- a/backend/tests/api/test_task_status_websocket.py
+++ b/backend/tests/api/test_task_status_websocket.py
@@ -25,6 +25,7 @@ class StubJobStatusManager:
         self.queue: asyncio.Queue | None = None
         self.loop: asyncio.AbstractEventLoop | None = None
         self.enabled = True
+        self.subscribe_result = True
 
     async def start(self) -> None:  # pragma: no cover - hook used in lifespan
         return None
@@ -35,7 +36,7 @@ class StubJobStatusManager:
     async def subscribe(self, task_id: str, queue: asyncio.Queue) -> bool:
         self.queue = queue
         self.loop = asyncio.get_running_loop()
-        return True
+        return self.subscribe_result
 
     async def unsubscribe(self, task_id: str, queue: asyncio.Queue) -> None:
         return None
@@ -145,6 +146,44 @@ def test_job_status_websocket_rejects_wrong_plan(job_record: tuple[UUID, UUID], 
         with pytest.raises(WebSocketDisconnect) as excinfo:
             with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={wrong_plan}") as websocket:
                 websocket.receive_text()
+
+    assert excinfo.value.code == 4404
+
+
+def test_job_status_websocket_closes_when_job_missing(
+    job_record: tuple[UUID, UUID], stub_job_status_manager: StubJobStatusManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """WebSocket should close with 4404 if the job disappears mid-stream."""
+
+    job_id, plan_id = job_record
+    monkeypatch.setattr(tasks_websocket, "DB_POLL_INTERVAL_SECONDS", 0.01)
+
+    with TestClient(create_app()) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={plan_id}") as websocket:
+                websocket.receive_json()
+                _cleanup_job(job_id, plan_id)
+                websocket.receive_text()
+
+    assert excinfo.value.code == 4404
+
+
+def test_job_status_websocket_rejects_plan_mismatch_during_stream(
+    job_record: tuple[UUID, UUID], stub_job_status_manager: StubJobStatusManager
+) -> None:
+    """If broker payloads reference a different plan, the WebSocket should be closed."""
+
+    job_id, plan_id = job_record
+
+    with TestClient(create_app()) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/api/ws/jobs/{job_id}?plan_id={plan_id}") as websocket:
+                initial = websocket.receive_json()
+                mismatched_payload = {**initial, "plan_id": str(uuid4()), "status": JobStatus.RUNNING.value}
+                stub_job_status_manager.push(
+                    {"task_id": initial["task_id"], "status": "PROGRESS", "result": mismatched_payload}
+                )
+                websocket.receive_json()
 
     assert excinfo.value.code == 4404
 

--- a/backend/tests/test_item_match_scoring.py
+++ b/backend/tests/test_item_match_scoring.py
@@ -8,6 +8,7 @@ from pytest import approx
 from backend.workers.tasks import item_matches
 from backend.workers.tasks.item_matches import (
     calculate_match_score,
+    normalize_text_for_matching,
     remove_brand_from_name,
     should_exclude_brand,
 )
@@ -215,3 +216,82 @@ class TestEdgeCases:
         score2 = calculate_match_score(["CREAM", "CHEESE"], "cream cheese")
         assert score1 == approx(100.0)
         assert score2 == approx(100.0)
+
+
+class TestNormalizeTextForMatching:
+    """Tests for normalize_text_for_matching function."""
+
+    def test_basic_lowercase(self) -> None:
+        """Should lowercase text."""
+        assert normalize_text_for_matching("Hello World") == "hello world"
+
+    def test_removes_hyphens(self) -> None:
+        """Should replace hyphens with spaces."""
+        assert normalize_text_for_matching("Band-Aid") == "band aid"
+
+    def test_removes_apostrophes(self) -> None:
+        """Should remove apostrophes."""
+        assert normalize_text_for_matching("McDonald's") == "mcdonalds"
+
+    def test_handles_umlaut(self) -> None:
+        """Should handle German umlauts like Häagen-Dazs."""
+        result = normalize_text_for_matching("Häagen-Dazs")
+        assert result == "haagen dazs"
+
+    def test_handles_accent(self) -> None:
+        """Should handle accented characters like José Olé."""
+        result = normalize_text_for_matching("José Olé")
+        assert result == "jose ole"
+
+    def test_handles_tilde(self) -> None:
+        """Should handle Spanish ñ character."""
+        result = normalize_text_for_matching("Jalapeño")
+        assert result == "jalapeno"
+
+    def test_handles_cedilla(self) -> None:
+        """Should handle French ç character."""
+        result = normalize_text_for_matching("Façade")
+        assert result == "facade"
+
+    def test_handles_mixed_characters(self) -> None:
+        """Should handle mixed special characters."""
+        result = normalize_text_for_matching("Crème Brûlée")
+        assert result == "creme brulee"
+
+
+class TestUnicodeBrandHandling:
+    """Tests for Unicode brand handling in scoring functions."""
+
+    def test_haagen_dazs_brand_exclusion(self) -> None:
+        """Should handle Häagen-Dazs brand correctly."""
+        # User searching for generic "ice cream" - brand should be excluded
+        assert should_exclude_brand(["ice", "cream"], "Häagen-Dazs") is True
+
+    def test_haagen_dazs_brand_search(self) -> None:
+        """Should detect when user searches for Häagen-Dazs."""
+        # User searching for "haagen dazs" (ASCII version) - brand should NOT be excluded
+        assert should_exclude_brand(["haagen", "dazs"], "Häagen-Dazs") is False
+
+    def test_jose_ole_brand_exclusion(self) -> None:
+        """Should handle José Olé brand correctly."""
+        assert should_exclude_brand(["burrito"], "José Olé") is True
+
+    def test_jose_ole_brand_search(self) -> None:
+        """Should detect when user searches for Jose Ole."""
+        assert should_exclude_brand(["jose", "ole"], "José Olé") is False
+
+    def test_unicode_brand_removal_from_name(self) -> None:
+        """Should remove Unicode brand from product name."""
+        result = remove_brand_from_name("Häagen-Dazs Vanilla Ice Cream", "Häagen-Dazs")
+        assert result == "Vanilla Ice Cream"
+
+    def test_unicode_scoring_with_brand_exclusion(self) -> None:
+        """Should score correctly when excluding Unicode brand."""
+        # Generic search for "ice cream" with Häagen-Dazs product
+        score = calculate_match_score(
+            ["ice", "cream"],
+            "Häagen-Dazs Ice Cream",
+            product_brand="Häagen-Dazs"
+        )
+        # Brand excluded, left with "Ice Cream" - should be perfect match
+        assert score == approx(100.0)

--- a/backend/tests/test_item_match_scoring.py
+++ b/backend/tests/test_item_match_scoring.py
@@ -1,0 +1,217 @@
+"""Unit tests for item match candidate scoring functions."""
+
+from __future__ import annotations
+
+import pytest
+from pytest import approx
+
+from backend.workers.tasks import item_matches
+from backend.workers.tasks.item_matches import (
+    calculate_match_score,
+    remove_brand_from_name,
+    should_exclude_brand,
+)
+
+
+class TestShouldExcludeBrand:
+    """Tests for should_exclude_brand function."""
+
+    def test_no_brand_returns_false(self) -> None:
+        """Should return False when no brand is provided."""
+        assert should_exclude_brand(["cream", "cheese"], None) is False
+
+    def test_direct_term_overlap_returns_false(self) -> None:
+        """Should return False when user searches for the brand directly."""
+        assert should_exclude_brand(["philadelphia"], "Philadelphia") is False
+        assert should_exclude_brand(["kleenex"], "Kleenex") is False
+
+    def test_no_overlap_returns_true(self) -> None:
+        """Should return True when user's search doesn't include the brand."""
+        assert should_exclude_brand(["cream", "cheese"], "Philadelphia") is True
+        assert should_exclude_brand(["tissues"], "Kleenex") is True
+
+    def test_hyphenated_brand_direct_match(self) -> None:
+        """Should handle hyphenated brands like Band-Aid."""
+        # "band" is in canon_terms, matches "band" from "Band-Aid"
+        assert should_exclude_brand(["band", "aid"], "Band-Aid") is False
+
+    def test_hyphenated_brand_compound_term(self) -> None:
+        """Should handle compound searches like 'bandaid' for 'Band-Aid'."""
+        # "bandaid" should match "bandaid" (brand_normalized.replace(" ", ""))
+        assert should_exclude_brand(["bandaid"], "Band-Aid") is False
+
+    def test_partial_brand_in_search(self) -> None:
+        """Should detect when brand term appears in search."""
+        assert should_exclude_brand(["philadelphia", "cream", "cheese"], "Philadelphia") is False
+
+    def test_brand_with_apostrophe(self) -> None:
+        """Should handle brands with apostrophes."""
+        assert should_exclude_brand(["mcdonalds"], "McDonald's") is False
+        assert should_exclude_brand(["burger"], "McDonald's") is True
+
+
+class TestRemoveBrandFromName:
+    """Tests for remove_brand_from_name function."""
+
+    def test_no_brand_returns_original(self) -> None:
+        """Should return original name when no brand provided."""
+        assert remove_brand_from_name("Cream Cheese", None) == "Cream Cheese"
+
+    def test_removes_brand_prefix(self) -> None:
+        """Should remove brand from start of product name."""
+        assert remove_brand_from_name("Philadelphia Cream Cheese", "Philadelphia") == "Cream Cheese"
+        assert remove_brand_from_name("Kleenex Tissues", "Kleenex") == "Tissues"
+
+    def test_case_insensitive_removal(self) -> None:
+        """Should remove brand case-insensitively."""
+        assert remove_brand_from_name("PHILADELPHIA Cream Cheese", "Philadelphia") == "Cream Cheese"
+        assert remove_brand_from_name("philadelphia cream cheese", "Philadelphia") == "cream cheese"
+
+    def test_brand_not_at_start_unchanged(self) -> None:
+        """Should not remove brand if not at start of name."""
+        assert remove_brand_from_name("Store Brand Philadelphia Style", "Philadelphia") == "Store Brand Philadelphia Style"
+
+
+class TestCalculateMatchScore:
+    """Tests for calculate_match_score function."""
+
+    def test_basic_exact_match(self) -> None:
+        """Exact term match should score 100."""
+        score = calculate_match_score(["cream", "cheese"], "Cream Cheese")
+        assert score == approx(100.0)
+
+    def test_extra_terms_penalty(self) -> None:
+        """Extra terms in product name should reduce score."""
+        score = calculate_match_score(["cream", "cheese"], "Cream Cheese Spread")
+        assert score < 100.0
+
+    def test_brand_exclusion_gives_perfect_score(self) -> None:
+        """Generic search with brand exclusion should score 100."""
+        score = calculate_match_score(["cream", "cheese"], "Philadelphia Cream Cheese", product_brand="Philadelphia")
+        assert score == approx(100.0)
+
+    def test_brand_exclusion_multiple_brands(self) -> None:
+        """Brand exclusion should work for various brands."""
+        score = calculate_match_score(["cream", "cheese"], "Hannaford Cream Cheese", product_brand="Hannaford")
+        assert score == approx(100.0)
+
+    def test_user_brand_search_keeps_brand(self) -> None:
+        """When user searches for brand, brand should be kept in scoring."""
+        score = calculate_match_score(["philadelphia", "cream", "cheese"], "Philadelphia Cream Cheese", product_brand="Philadelphia")
+        assert score == approx(100.0)
+
+    def test_position_weighting_prefers_early_matches(self) -> None:
+        """Matches in earlier positions should score higher."""
+        # "Cream Cheese Spread" matches at positions 0, 1
+        # "Organic Cream Cheese" matches at positions 1, 2
+        score_early = calculate_match_score(["cream", "cheese"], "Cream Cheese Spread")
+        score_late = calculate_match_score(["cream", "cheese"], "Organic Cream Cheese")
+        assert score_early > score_late
+
+    def test_genericized_trademark_kleenex(self) -> None:
+        """User searching 'kleenex' should keep brand in scoring."""
+        score = calculate_match_score(["kleenex"], "Kleenex Tissues", product_brand="Kleenex")
+        # Brand NOT excluded, so "kleenex" matches position 0 only
+        # Total weight: 1.0 + 0.9 = 1.9
+        # Matched weight: 1.0 (position 0)
+        # Score: 1.0 / 1.9 * 100 ≈ 52.63
+        assert score < 60.0
+        assert score > 40.0
+
+    def test_generic_search_excludes_brand(self) -> None:
+        """User searching 'tissues' should exclude brand for perfect match."""
+        score = calculate_match_score(["tissues"], "Kleenex Tissues", product_brand="Kleenex")
+        # Brand excluded, left with "Tissues"
+        assert score == approx(100.0)
+
+    def test_empty_product_name_returns_zero(self) -> None:
+        """Empty product name should return 0."""
+        score = calculate_match_score(["cream", "cheese"], "")
+        assert score == approx(0.0)
+
+    def test_green_onion_exact_match(self) -> None:
+        """Green onion exact match should score 100."""
+        score = calculate_match_score(["green", "onion"], "Green Onion")
+        assert score == approx(100.0)
+
+    def test_green_onion_with_organic_prefix(self) -> None:
+        """Organic prefix should reduce score for 'green onion' search."""
+        score = calculate_match_score(["green", "onion"], "Organic Green Onion")
+        assert score < 100.0
+
+    def test_organic_green_onion_exact_match(self) -> None:
+        """Organic green onion exact match should score 100."""
+        score = calculate_match_score(["organic", "green", "onion"], "Organic Green Onion")
+        assert score == approx(100.0)
+
+
+class TestCalculateMatchScoreWithFlagsDisabled:
+    """Tests for calculate_match_score with feature flags disabled."""
+
+    def test_brand_exclusion_disabled(self) -> None:
+        """With brand exclusion disabled, brand should reduce score."""
+        original_flag = item_matches.ENABLE_BRAND_EXCLUSION
+        try:
+            item_matches.ENABLE_BRAND_EXCLUSION = False
+            score = calculate_match_score(["cream", "cheese"], "Philadelphia Cream Cheese", product_brand="Philadelphia")
+            assert score < 100.0
+        finally:
+            item_matches.ENABLE_BRAND_EXCLUSION = original_flag
+
+    def test_position_weighting_disabled(self) -> None:
+        """With position weighting disabled, use simple term coverage."""
+        original_flag = item_matches.ENABLE_POSITION_WEIGHTING
+        try:
+            item_matches.ENABLE_POSITION_WEIGHTING = False
+            # 2 terms match out of 3 product terms = 2/3 * 100 = 66.67
+            score = calculate_match_score(["cream", "cheese"], "Cream Cheese Spread")
+            assert score == approx(66.67)
+        finally:
+            item_matches.ENABLE_POSITION_WEIGHTING = original_flag
+
+    def test_both_flags_disabled_simple_coverage(self) -> None:
+        """With both flags disabled, use simple term coverage without brand exclusion."""
+        original_brand = item_matches.ENABLE_BRAND_EXCLUSION
+        original_position = item_matches.ENABLE_POSITION_WEIGHTING
+        try:
+            item_matches.ENABLE_BRAND_EXCLUSION = False
+            item_matches.ENABLE_POSITION_WEIGHTING = False
+            # 2 terms match out of 3 product terms = 2/3 * 100 = 66.67
+            score = calculate_match_score(["cream", "cheese"], "Philadelphia Cream Cheese", product_brand="Philadelphia")
+            assert score == approx(66.67)
+        finally:
+            item_matches.ENABLE_BRAND_EXCLUSION = original_brand
+            item_matches.ENABLE_POSITION_WEIGHTING = original_position
+
+
+class TestEdgeCases:
+    """Tests for edge cases in scoring."""
+
+    def test_single_term_search(self) -> None:
+        """Single term search should work correctly."""
+        score = calculate_match_score(["milk"], "Milk")
+        assert score == approx(100.0)
+
+    def test_many_product_terms(self) -> None:
+        """Products with many terms should be handled correctly."""
+        score = calculate_match_score(["cream", "cheese"], "Philadelphia Original Whipped Cream Cheese Spread")
+        # Brand excluded, left with "Original Whipped Cream Cheese Spread" (5 terms)
+        # Matches at positions 2, 3 (cream, cheese)
+        assert score < 100.0
+        assert score > 0.0
+
+    def test_parenthetical_in_product_name(self) -> None:
+        """Products with parentheticals should be handled."""
+        score = calculate_match_score(["green", "onion"], "Green Onion (Hannaford)", product_brand="Hannaford")
+        # Brand "Hannaford" is in parentheses, not at start - won't be removed
+        # But brand exclusion check will still see no overlap, so it's fine
+        # Product terms: ["green", "onion", "(hannaford)"]
+        # Matches: positions 0, 1
+        assert score > 0.0
+
+    def test_case_insensitive_matching(self) -> None:
+        """Matching should be case insensitive."""
+        score1 = calculate_match_score(["cream", "cheese"], "CREAM CHEESE")
+        score2 = calculate_match_score(["CREAM", "CHEESE"], "cream cheese")
+        assert score1 == approx(100.0)
+        assert score2 == approx(100.0)

--- a/backend/tests/test_item_match_tasks.py
+++ b/backend/tests/test_item_match_tasks.py
@@ -225,7 +225,8 @@ def test_create_item_match_candidates_generates_unique_candidates() -> None:
 
         assert product_ids == {product_milk_id, product_oatmilk_id}
         assert existing_candidate_id not in candidate_ids
-        assert all(candidate.score == 100 for candidate in candidates)
+        # Scores now vary based on term coverage heuristic (0-100 range)
+        assert all(0 < candidate.score <= 100 for candidate in candidates)
 
     _delete_entities(entity_ids)
 
@@ -488,7 +489,8 @@ def test_create_item_match_candidates_handles_branded_and_unbranded_items() -> N
         by_item: dict[UUID, list[ItemMatchCandidate]] = defaultdict(list)
         for candidate in candidates:
             by_item[candidate.list_item_id].append(candidate)
-            assert candidate.score == 100
+            # Scores now vary based on term coverage heuristic (0-100 range)
+            assert 0 < candidate.score <= 100
 
         for item_id, expected_names in list_item_ids.items():
             assert item_id in by_item

--- a/backend/workers/tasks/__init__.py
+++ b/backend/workers/tasks/__init__.py
@@ -1,6 +1,10 @@
 """Task modules for Celery workers."""
 
 from . import health  # noqa: F401
-from .item_matches import create_item_match_candidates  # noqa: F401
+from .item_matches import create_item_match_candidates, fanout_candidates_to_item_matches  
 
-__all__ = ["health", "create_item_match_candidates"]
+__all__ = [
+    "health",
+    "create_item_match_candidates",
+    "fanout_candidates_to_item_matches",
+]

--- a/backend/workers/tasks/item_matches.py
+++ b/backend/workers/tasks/item_matches.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unicodedata
 from uuid import UUID
 
 from celery import shared_task
@@ -21,20 +22,37 @@ POSITION_WEIGHTS = [1.0, 0.9, 0.8, 0.7, 0.6]
 DEFAULT_WEIGHT = 0.5
 
 
+def normalize_text_for_matching(text: str) -> str:
+    """Normalize text for matching, handling non-ASCII characters.
+
+    Handles brands like "Häagen-Dazs", "José Olé" by:
+    1. NFKD normalization to decompose characters
+    2. Removing combining marks (accents)
+    3. Lowercasing and normalizing separators
+    """
+    # NFKD normalization decomposes characters (é -> e + combining accent)
+    normalized = unicodedata.normalize("NFKD", text)
+    # Remove combining marks (accents, umlauts, etc.)
+    ascii_compatible = "".join(c for c in normalized if not unicodedata.combining(c))
+    # Lowercase and normalize common separators
+    return ascii_compatible.lower().replace("-", " ").replace("'", "")
+
+
 def should_exclude_brand(canon_terms: list[str], brand: str | None) -> bool:
     """
     Determine if brand should be excluded from scoring.
 
     Returns False (don't exclude) if user's search terms overlap with brand.
     Handles genericized trademarks like "kleenex", "bandaid", etc.
+    Also handles non-ASCII brand names like "Häagen-Dazs", "José Olé".
     """
     if not brand:
         return False
 
-    # Normalize brand: lowercase, split hyphenated/apostrophe words
-    brand_normalized = brand.lower().replace("-", " ").replace("'", "")
+    # Normalize brand: handle non-ASCII, lowercase, split hyphenated/apostrophe words
+    brand_normalized = normalize_text_for_matching(brand)
     brand_terms = set(brand_normalized.split())
-    canon_lower = {t.lower() for t in canon_terms}
+    canon_lower = {normalize_text_for_matching(t) for t in canon_terms}
 
     # Check 1: Direct term overlap (e.g., "kleenex" in ["kleenex"])
     if brand_terms & canon_lower:
@@ -50,15 +68,32 @@ def should_exclude_brand(canon_terms: list[str], brand: str | None) -> bool:
 
 
 def remove_brand_from_name(product_name: str, brand: str | None) -> str:
-    """Remove brand prefix from product name for scoring purposes."""
+    """Remove brand prefix from product name for scoring purposes.
+
+    Handles non-ASCII characters by using normalized comparison.
+    """
     if not brand:
         return product_name
 
-    name_lower = product_name.lower()
-    brand_lower = brand.lower()
+    name_normalized = normalize_text_for_matching(product_name)
+    brand_normalized = normalize_text_for_matching(brand)
 
-    if name_lower.startswith(brand_lower):
-        return product_name[len(brand) :].strip()
+    if name_normalized.startswith(brand_normalized):
+        # Find the actual position to cut by matching normalized prefix length
+        # We need to find where in the original string the brand ends
+        chars_consumed = 0
+        normalized_pos = 0
+        target_normalized_len = len(brand_normalized)
+
+        for i, char in enumerate(product_name):
+            char_normalized = normalize_text_for_matching(char)
+            if char_normalized:  # Skip if char normalizes to empty (e.g., combining marks)
+                normalized_pos += len(char_normalized)
+            chars_consumed = i + 1
+            if normalized_pos >= target_normalized_len:
+                break
+
+        return product_name[chars_consumed:].strip()
 
     return product_name
 
@@ -110,7 +145,7 @@ def calculate_match_score(
 
 @shared_task(bind=True, name="workers.item_matches.create_item_match_candidates", track_started=True)
 def create_item_match_candidates(self, job_id: str | UUID) -> dict[str, str]:
-    """Create Item Matche Candidates for each List Item job."""
+    """Create Item Match Candidates for each List Item in a route plan."""
 
     try:
         # get job details from DB and preload related data

--- a/backend/workers/tasks/item_matches.py
+++ b/backend/workers/tasks/item_matches.py
@@ -12,6 +12,101 @@ from backend.app.db import session_scope
 from backend.app.models import ItemMatch, ItemMatchCandidate, Job, JobStage, Product, RoutePlan, ShoppingList, StoreProduct
 from backend.app.tasks import mark_job_failed, mark_job_running, mark_job_success, record_job_progress
 
+# Scoring feature flags
+ENABLE_BRAND_EXCLUSION = True
+ENABLE_POSITION_WEIGHTING = True
+
+# Position weights for position weighting
+POSITION_WEIGHTS = [1.0, 0.9, 0.8, 0.7, 0.6]
+DEFAULT_WEIGHT = 0.5
+
+
+def should_exclude_brand(canon_terms: list[str], brand: str | None) -> bool:
+    """
+    Determine if brand should be excluded from scoring.
+
+    Returns False (don't exclude) if user's search terms overlap with brand.
+    Handles genericized trademarks like "kleenex", "bandaid", etc.
+    """
+    if not brand:
+        return False
+
+    # Normalize brand: lowercase, split hyphenated/apostrophe words
+    brand_normalized = brand.lower().replace("-", " ").replace("'", "")
+    brand_terms = set(brand_normalized.split())
+    canon_lower = {t.lower() for t in canon_terms}
+
+    # Check 1: Direct term overlap (e.g., "kleenex" in ["kleenex"])
+    if brand_terms & canon_lower:
+        return False
+
+    # Check 2: Substring match for compound terms
+    # Handles "bandaid" matching "Band-Aid" (brand_normalized = "band aid")
+    for canon_term in canon_lower:
+        if canon_term in brand_normalized or brand_normalized.replace(" ", "") in canon_term:
+            return False
+
+    return True
+
+
+def remove_brand_from_name(product_name: str, brand: str | None) -> str:
+    """Remove brand prefix from product name for scoring purposes."""
+    if not brand:
+        return product_name
+
+    name_lower = product_name.lower()
+    brand_lower = brand.lower()
+
+    if name_lower.startswith(brand_lower):
+        return product_name[len(brand) :].strip()
+
+    return product_name
+
+
+def get_position_weight(position: int) -> float:
+    """Get weight for a term at given position (0-indexed)."""
+    if position < len(POSITION_WEIGHTS):
+        return POSITION_WEIGHTS[position]
+    return DEFAULT_WEIGHT
+
+
+def calculate_match_score(
+    canon_terms: list[str],
+    product_name: str,
+    product_brand: str | None = None,
+) -> float:
+    """
+    Calculate match score for a product candidate.
+
+    Args:
+        canon_terms: Normalized search terms from user's list item
+        product_name: Product name to score against
+        product_brand: Product brand (optional, for brand exclusion)
+
+    Returns:
+        Score from 0-100 where 100 is a perfect match
+    """
+    # Only exclude brand if user isn't searching for it
+    scoring_name = product_name
+    if ENABLE_BRAND_EXCLUSION and should_exclude_brand(canon_terms, product_brand):
+        scoring_name = remove_brand_from_name(product_name, product_brand)
+
+    product_terms = [t.lower() for t in scoring_name.split() if t]
+    if not product_terms:
+        return 0.0
+
+    canon_terms_lower = {t.lower() for t in canon_terms}
+
+    if ENABLE_POSITION_WEIGHTING:
+        total_weight = sum(get_position_weight(i) for i in range(len(product_terms)))
+        matched_weight = sum(get_position_weight(i) for i, term in enumerate(product_terms) if term in canon_terms_lower)
+        score = (matched_weight / total_weight) * 100
+    else:
+        coverage = len(canon_terms) / len(product_terms)
+        score = min(coverage, 1.0) * 100
+
+    return round(score, 2)
+
 
 @shared_task(bind=True, name="workers.item_matches.create_item_match_candidates", track_started=True)
 def create_item_match_candidates(self, job_id: str | UUID) -> dict[str, str]:
@@ -63,11 +158,11 @@ def create_item_match_candidates(self, job_id: str | UUID) -> dict[str, str]:
                 if not canon_terms:
                     raise ValueError(f"Item {item.id} has no usable canonical terms for matching")
 
-                matched_product_ids: set[UUID] = set()
+                matched_products: dict[UUID, tuple[str, str | None]] = {}
                 for store in selected_stores:
                     # select products at this store where name contains all canon terms
                     statement = (
-                        select(Product.id)
+                        select(Product.id, Product.name, Product.brand)
                         .join(StoreProduct, StoreProduct.product_id == Product.id)
                         .where(
                             StoreProduct.store_id == store.store_id,
@@ -75,15 +170,18 @@ def create_item_match_candidates(self, job_id: str | UUID) -> dict[str, str]:
                         )
                     )
                     matches = session.exec(statement).all()
-                    matched_product_ids.update(matches)
+                    for product_id, product_name, product_brand in matches:
+                        if product_id not in matched_products:
+                            matched_products[product_id] = (product_name, product_brand)
 
                 # create item match candidates for matched products
-                for product_id in matched_product_ids:
+                for product_id, (product_name, product_brand) in matched_products.items():
+                    score = calculate_match_score(canon_terms, product_name, product_brand)
                     item_match_candidate = ItemMatchCandidate(
                         plan_id=plan.id,
                         list_item_id=item.id,
                         product_id=product_id,
-                        score=100,  # placeholder score
+                        score=score,
                     )
                     session.add(item_match_candidate)
                 session.commit()


### PR DESCRIPTION
- Reorganize FastAPI routers into catalog, lists, and planning namespaces with clearer helpers/schemas.
- Add planning job endpoints (plans, candidates, runs) plus TaskStatus WebSocket feed for live job state updates.
- Permit multiple job records per stage while keeping only one active. includes new Alembic migration and config tweaks.
- Improve item-matching worker scoring heuristics and task handling. expand models for richer status tracking.
- Increase automated coverage with new tests for planning jobs, task-status WebSocket, item-match scoring, and flow regressions.